### PR TITLE
meta.github: fix publish workflows

### DIFF
--- a/.github/workflows/publish-dryrun.yml
+++ b/.github/workflows/publish-dryrun.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   publish-crates-dryrun:
     name: Publish crates - dryrun
-    needs: build-package
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,6 @@ jobs:
   publish-crates:
     if: github.event.pull_request.merged == true
     name: Publish crates
-    needs: build-package
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Accidentally left a `needs` key in there.